### PR TITLE
Add AutoBreak Case

### DIFF
--- a/Source/Backlang-Compiler/compilation.back
+++ b/Source/Backlang-Compiler/compilation.back
@@ -61,7 +61,7 @@ func main() static -> none {
 	let myChar = 'a';
 
 	switch myChar {
-		case 'b' || 'c': print("It's B!");
+		break case 'b' || 'c': print("It's B!");
 		if isAlpha(myChar): {
 			print("It's...");
 			print("a C!");
@@ -69,6 +69,7 @@ func main() static -> none {
 		case 'w': break;
 		default: print("i dont know what it is :c");
 	}
+
 	Point::new(1, 2);
 	
 	nameof(msg);


### PR DESCRIPTION
with adds support for this syntax:

```
switch element {
   break case value: print("yay");
}
```

this will convert to:

```
switch element {
   case value: {
      print("yay");
      break;
   }
}
```